### PR TITLE
Updates kubeconfig.tf, adds scripts/retrieve_kubeconfig.sh, uses exte…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ server-ca.crt
 client-admin.crt
 client-admin.key
 *-config
-scripts/
 cluster-config-k3s

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -1,18 +1,9 @@
-resource "null_resource" "cluster" {
-  depends_on = [digitalocean_database_cluster.rancherdb, digitalocean_droplet.controller-init, digitalocean_droplet.controller-peer]
-
-  provisioner "local-exec" {
-    command = "sleep 1; /usr/bin/ssh -i ${pathexpand(format("%s", local.ssh_key_name))} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q root@${digitalocean_droplet.controller-init.ipv4_address} cat /etc/rancher/k3s/k3s.yaml | sed -e 's|127.0.0.1:6443|${digitalocean_droplet.controller-init.ipv4_address}:6443|g' -e 's|/var/lib/rancher/k3s/server/tls/||g' | tee -a ${path.module}/cluster-config-k3s"
-  }
-
-  provisioner "local-exec" {
-    command = "kubectl --kubeconfig=cluster-config-k3s get nodes"
-  }
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = "rm ${path.module}/cluster-config-k3s"
-  }
-
+data "external" "k3s_config" {
+  program = ["/bin/bash", "${path.module}/scripts/retrieve_kubeconfig.sh", "${digitalocean_droplet.controller-init.ipv4_address}", "${pathexpand(format("%s", local.ssh_key_name))}"]
 }
 
+resource "local_file" "cluster_k3s_config" {
+  content         = textdecodebase64(data.external.k3s_config.result.kubeconfig, "UTF-8")
+  filename        = pathexpand(format("%s-config", var.cluster_name))
+  file_permission = "0600"
+}

--- a/scripts/retrieve_kubeconfig.sh
+++ b/scripts/retrieve_kubeconfig.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+CONTROLLER_IP=$1
+KEY_PATH=$2
+
+/bin/sleep 1 ; \
+CONFIG=$(/usr/bin/ssh -i \
+$KEY_PATH \
+-o StrictHostKeyChecking=no \
+-o UserKnownHostsFile=/dev/null -q \
+root@$CONTROLLER_IP cat /etc/rancher/k3s/k3s.yaml \
+| sed -e "s|127.0.0.1:6443|$CONTROLLER_IP:6443|g" \
+-e 's|/var/lib/rancher/k3s/server/tls/||g' | base64 -b 0)
+
+echo -e "{\"kubeconfig\": \"$CONFIG\"}"
+


### PR DESCRIPTION
…rnal data, rather than null_resource and redirect, to pull and repopulate kubeconfig for created cluster to allow the config itself to be in retrievable in state as formatted base64, as well as easier clean-up on destroy rather than a destroy-time local-exec.

Signed-off-by: Joseph D. Marhee <jmarhee@interiorae.com>